### PR TITLE
fix for missing twig ceil filter

### DIFF
--- a/Resources/views/Mapping/_pagination.html.twig
+++ b/Resources/views/Mapping/_pagination.html.twig
@@ -1,4 +1,4 @@
-{% set totalPages = (paginator.count / pageSize)|ceil %}
+{% set totalPages = (paginator.count / pageSize)|round(0, 'ceil') %}
 {% set currentPage = page %}
 {% if totalPages > 1 %}
     <div class="pagination">


### PR DESCRIPTION
Twig has no ceil filter by default, but there is round(0, 'ceil')